### PR TITLE
run: Added StreamResult Error Handling

### DIFF
--- a/commands/run.js
+++ b/commands/run.js
@@ -25,7 +25,7 @@ class RunCommand extends Command {
     super('run');
   }
 
-  help () {
+  help() {
     return {
       description: 'Runs a function in the local project',
       args: [],
@@ -39,7 +39,7 @@ class RunCommand extends Command {
     };
   }
 
-  async run (params) {
+  async run(params) {
 
     // Use 8199 for test runs
     const Funct = await loadFunct(params, true);
@@ -77,11 +77,11 @@ class RunCommand extends Command {
     }
 
     const proc = localServer.run({ port, isBackground: true });
-    
     let isConnected = false;
     proc.stdout.on('data', data => {
       const message = data.toString();
-      if (message.includes(`*** Listening on localhost:${port}`)) {
+
+      if (message.includes(`*** Listening on localhost:${port}`) || message.includes(`listening on port ${port}`)) {
         isConnected = true;
       }
     });
@@ -113,7 +113,7 @@ class RunCommand extends Command {
     const bodyParams = (method === 'post' || method === 'put')
       ? JSON.stringify(functionParams)
       : '';
-    
+
     let result;
     const streamResult = await io.request(
       method.toUpperCase(),
@@ -121,7 +121,7 @@ class RunCommand extends Command {
       queryParams,
       {},
       bodyParams,
-      ({id, event, data}) => {
+      ({ id, event, data }) => {
         let json;
         try {
           json = JSON.parse(data);
@@ -142,6 +142,12 @@ class RunCommand extends Command {
         }
       }
     );
+
+    // Handle non-event errors given by server
+    if (streamResult.statusCode === 500) {
+      const errorBody = streamResult.body.toString();
+      throw new Error(errorBody);
+    }
 
     // retrieve details
     const body = result.body.toString();

--- a/commands/run.js
+++ b/commands/run.js
@@ -83,9 +83,7 @@ class RunCommand extends Command {
 
       if (message.includes(`*** Listening on localhost:${port}`)) {
         isConnected = true;
-      }
-
-      if (message.includes(`Unable to spawn HTTP Workers, listening on port ${port}`)) {
+      } else if (message.includes(`Unable to spawn HTTP Workers, listening on port ${port}`)) {
         isConnected = true;
       }
     });
@@ -150,10 +148,14 @@ class RunCommand extends Command {
     // Handle non-event errors given by server
     if (streamResult.statusCode === 500) {
       const errorBody = streamResult.body.toString();
-      // Only halt on application errors
+      let errorMessage = errorBody;
+      // cut out the "Application Error: " prefix and only capture the first line
       if (errorBody.startsWith('Application Error:')) {
-        throw new Error(errorBody);
+        errorMessage = errorBody.slice('Application Error: '.length);
       }
+      // ignore the stack trace
+      errorMessage = errorMessage.split('\n')[0];
+      throw new Error(errorMessage);
     }
 
     // retrieve details

--- a/commands/run.js
+++ b/commands/run.js
@@ -81,7 +81,11 @@ class RunCommand extends Command {
     proc.stdout.on('data', data => {
       const message = data.toString();
 
-      if (message.includes(`*** Listening on localhost:${port}`) || message.includes(`listening on port ${port}`)) {
+      if (message.includes(`*** Listening on localhost:${port}`)) {
+        isConnected = true;
+      }
+
+      if (message.includes(`Unable to spawn HTTP Workers, listening on port ${port}`)) {
         isConnected = true;
       }
     });
@@ -146,7 +150,10 @@ class RunCommand extends Command {
     // Handle non-event errors given by server
     if (streamResult.statusCode === 500) {
       const errorBody = streamResult.body.toString();
-      throw new Error(errorBody);
+      // Only halt on application errors
+      if (errorBody.startsWith('Application Error:')) {
+        throw new Error(errorBody);
+      }
     }
 
     // retrieve details


### PR DESCRIPTION
When Instant API detects an incorrect schema, it results in a 500 error.

This error is not captured in `funct run /` for example because of two reasons:

- We aren't capturing the isConnected message, even though it does connect
- The error is NOT event message streamed. I tested this using console.log

We need to look into StreamResult when we have a 500 result and pull the error out from there.

Also ran Format

type error before change: 

<img width="963" alt="image" src="https://github.com/user-attachments/assets/69e09157-2b91-422a-9646-ea6ffd39b2ec" />


type error after change:

<img width="963" alt="image" src="https://github.com/user-attachments/assets/c52b4d3f-19d1-4fc4-ae5a-89d96973e91d" />
